### PR TITLE
Add proper installation location of skins in macOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,8 @@ To view a preview of the skin visit www.pressureforsteam.com
 1. Download the [latest release.](https://github.com/DirtDiglett/Pressure2/releases/latest)
 2. Extract the ZIP and move the folder to:
 	* Windows: the `Program Files (x86)/Steam/skins` folder, or your Steam install directory if different.
-	* Mac: right-click `Steam.app` and choose `show package contents` then go to - `/Contents/MacOS/skins`
+	* Mac: In Finder, select `Go > Go to Folder` and type `~/users/user_name/library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/skins`
+	  * Replace `user_name` with the relavent username found on your computer
 	* Linux: the `~/.local/share/Steam/skins/` folder
     * Ubuntu: the `~/.steam/skins` folder
 3. Open the folder `fonts` found inside the Pressure² folder, and for the files in here:

--- a/readme.md
+++ b/readme.md
@@ -12,8 +12,9 @@ To view a preview of the skin visit www.pressureforsteam.com
 1. Download the [latest release.](https://github.com/DirtDiglett/Pressure2/releases/latest)
 2. Extract the ZIP and move the folder to:
 	* Windows: the `Program Files (x86)/Steam/skins` folder, or your Steam install directory if different.
-	* Mac: In Finder, select `Go > Go to Folder` and type `~/users/user_name/library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/skins`
+	* Mac: Place into the directory `~/users/user_name/library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/skins`
 	  * Replace `user_name` with the relavent username found on your computer
+	  * If you do not see the library folder, go to your username folder, and go to `View > Show View Options` and check the box `Show Library Folder`.
 	* Linux: the `~/.local/share/Steam/skins/` folder
     * Ubuntu: the `~/.steam/skins` folder
 3. Open the folder `fonts` found inside the Pressure² folder, and for the files in here:


### PR DESCRIPTION
Currently `README.md` tells people to place the folder into the wrong location which does not work.  This fixes it.